### PR TITLE
only set the Logger's progname if the logger has an accessor

### DIFF
--- a/lib/stacker_bee/middleware/logger.rb
+++ b/lib/stacker_bee/middleware/logger.rb
@@ -13,7 +13,7 @@ module StackerBee
       def initialize(app, _logger = nil)
         super(app)
         self.logger = _logger
-        logger.progname ||= PROGNAME
+        logger.progname ||= PROGNAME if logger.respond_to?(:progname=)
       end
 
       def logger


### PR DESCRIPTION
The Logger in Ruby's stdlib has a `#progname=` accessor, but not every logger does. Neither TwP's Logging gem or the [Graylog logger](https://github.com/Graylog2/gelf-rb) have it.

This PR checks to see if the logger has the accessor before using it. 

I don't think Avdi Grimm would love it. But if we want to have a swappable logger without forcing users to write their own middleware, then it's either 1) this 2) putting a disclaimer in the docs or 3) defining an accessor on the singleton class. Of the 3, this one seems the best to me.
