### PR TITLE
Configurable Middleware::Logger for StackerBee

### DIFF
--- a/lib/stacker_bee/client.rb
+++ b/lib/stacker_bee/client.rb
@@ -21,7 +21,9 @@ module StackerBee
                    :api_key,
                    :api_key=,
                    :secret_key,
-                   :secret_key=
+                   :secret_key=,
+                   :middleware_logger,
+                   :middleware_logger=
 
     class << self
       def reset!
@@ -30,7 +32,8 @@ module StackerBee
 
       def default_config
         @default_config ||= {
-          allow_empty_string_params: false
+          allow_empty_string_params: false,
+          middleware_logger: Middleware::Logger
         }
       end
 

--- a/lib/stacker_bee/connection.rb
+++ b/lib/stacker_bee/connection.rb
@@ -24,7 +24,7 @@ module StackerBee
       @faraday = Faraday.new(url: uri.to_s) do |faraday|
         faraday.use      Middleware::Detokenizer
         faraday.use      Middleware::SignedQuery, configuration.secret_key
-        faraday.use      Middleware::Logger, configuration.logger
+        faraday.use      configuration.middleware_logger, configuration.logger
         faraday.adapter  Faraday.default_adapter  # Net::HTTP
       end
     end

--- a/spec/units/stacker_bee/client_spec.rb
+++ b/spec/units/stacker_bee/client_spec.rb
@@ -96,11 +96,13 @@ describe StackerBee::Client, "configuration" do
   let(:default_url)         { "default_cloud-stack.com" }
   let(:default_api_key)     { "default-cloud-stack-api-key" }
   let(:default_secret_key)  { "default-cloud-stack-secret-key" }
+  let(:default_middleware_logger) { double }
   let(:default_config_hash) do
     {
       url:        default_url,
       api_key:    default_api_key,
       secret_key: default_secret_key,
+      middleware_logger: default_middleware_logger,
       allow_empty_string_params: false
     }
   end
@@ -110,12 +112,14 @@ describe StackerBee::Client, "configuration" do
   let(:instance_url)        { "instance-cloud-stack.com" }
   let(:instance_api_key)    { "instance-cloud-stack-api-key" }
   let(:instance_secret_key) { "instance-cloud-stack-secret-key" }
+  let(:middleware_logging_class) { double }
   let(:instance_config_hash) do
     {
       url:        instance_url,
       api_key:    instance_api_key,
       secret_key: instance_secret_key,
-      allow_empty_string_params: false
+      allow_empty_string_params: false,
+      middleware_logger: middleware_logging_class
     }
   end
   let!(:instance_configuration) do
@@ -149,6 +153,7 @@ describe StackerBee::Client, "configuration" do
       its(:url)           { should eq instance_url }
       its(:api_key)       { should eq instance_api_key }
       its(:secret_key)    { should eq instance_secret_key }
+      its(:middleware_logger) { should eq middleware_logging_class }
     end
 
     context "with instance-specific configuration that's not a hash" do
@@ -158,6 +163,7 @@ describe StackerBee::Client, "configuration" do
       its(:url)           { should eq instance_url }
       its(:api_key)       { should eq instance_api_key }
       its(:secret_key)    { should eq instance_secret_key }
+      its(:middleware_logger) { should eq middleware_logging_class }
     end
 
     describe "#url" do

--- a/spec/units/stacker_bee/connection_spec.rb
+++ b/spec/units/stacker_bee/connection_spec.rb
@@ -7,39 +7,62 @@ describe StackerBee::Connection do
   let(:query_params)  { [[:foo, :bar]] }
   let(:request)       { double query_params: query_params }
   let(:response)      { double }
-  let(:faraday)       { double get: response }
+  let(:faraday)       { double get: response, adapter: nil }
   let(:connection)    { StackerBee::Connection.new configuration }
-  subject { connection.get request }
   before do
     Faraday.stub(:new) { faraday }
   end
 
-  context "successfully connecting" do
+  describe "#initialize_connection" do
+    let(:middleware_logging_class) { double }
+    let(:logger)                   { double }
+    let(:adapter)                  { double }
+    let(:configuration) { double url: url,
+                          secret_key: secret_key,
+                          middleware_logger: middleware_logging_class,
+                          logger: logger,
+                          adapter: adapter }
+    subject { connection }
+
     before do
-      faraday.should_receive(:get).with('/foo/bar/', query_params) { response }
+      Faraday.stub(:new) { faraday }.and_yield( faraday )
+      faraday.stub(:use)
     end
-    it { should be response }
-    it "specifies url without path when creating connection" do
+    it "should use the provided middleware_logging class" do
       subject
-      Faraday.should have_received(:new).with(url: "http://test.com:1234")
+      faraday.should have_received(:use).with(middleware_logging_class, logger)
     end
   end
 
-  context "failing to connect" do
-    before do
-      faraday.stub(:get) { fail Faraday::Error::ConnectionFailed, "boom" }
+  describe "#get" do
+    subject { connection.get request }
+    context "successfully connecting" do
+      before do
+        faraday.should_receive(:get).with('/foo/bar/', query_params) { response }
+      end
+      it { should be response }
+      it "specifies url without path when creating connection" do
+        subject
+        Faraday.should have_received(:new).with(url: "http://test.com:1234")
+      end
     end
-    it "should raise helpful exception" do
-      klass = StackerBee::ConnectionError
-      expect(-> { subject }).to raise_error klass, /#{url}/
-    end
-  end
 
-  context "no protocol specified in URL" do
-    let(:url) { "wrong.com" }
-    it "should raise helpful exception" do
-      klass = StackerBee::ConnectionError
-      expect(-> { subject }).to raise_error klass, /no protocol/
+    context "failing to connect" do
+      before do
+        faraday.stub(:get) { fail Faraday::Error::ConnectionFailed, "boom" }
+      end
+      it "should raise helpful exception" do
+        klass = StackerBee::ConnectionError
+        expect(-> { subject }).to raise_error klass, /#{url}/
+      end
+    end
+
+    context "no protocol specified in URL" do
+      let(:url) { "wrong.com" }
+      it "should raise helpful exception" do
+        klass = StackerBee::ConnectionError
+        expect(-> { subject }).to raise_error klass, /no protocol/
+      end
     end
   end
 end

--- a/stacker_bee.gemspec
+++ b/stacker_bee.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock",  "~> 1.15"
   spec.add_development_dependency "vcr",      "~> 2.6"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
When setting up logging to graylog, we wanted to be able write the
entire log message as 1 log event, to make searching easier.

However, the log events were being written in
StackerBee::Middleware::Logger, which wasn't accessible.

This patch makes the Middleware::Logger configurable. If you provide a
different class to the StackerBee::Client, then it will use that class
instead of the default (which is StackerBee::Middleware::Logger)

to override the default, pass the class during initalization:

```
client = StackerBee::Client.new(
  ...
  middleware_logger: Custom::MiddlewareLogger
)
```

Feedback wanted! (this is more of a 'start-the-conversation' pull request)

(Original Issue: #23)
