### PR TITLE
Add lib dir to loadpath

### DIFF
--- a/bin/stacker_bee
+++ b/bin/stacker_bee
@@ -1,4 +1,7 @@
 #! /usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
+
 require 'optparse'
 require 'stacker_bee'
 require 'json'


### PR DESCRIPTION
Running bin/stacker_bee when the gem was not previously installed would fail to
find 'stacker_bee' during require
