### PR TITLE
Require logger in binary

### DIFF
--- a/bin/stacker_bee
+++ b/bin/stacker_bee
@@ -71,8 +71,6 @@ if verbose
   puts "StackerBee version #{StackerBee::VERSION}"
   puts "URL: #{options["url"]}"
   puts "API key: #{options["api_key"]}"
-else
-  options['logger'] = Logger.new('/dev/null')
 end
 
 client = StackerBee::Client.new(options)


### PR DESCRIPTION
Fails on line 72/73 if --verbose is not passed
