### PR TITLE
Add console access method

### DIFF
--- a/lib/stacker_bee/body_parser.rb
+++ b/lib/stacker_bee/body_parser.rb
@@ -6,7 +6,17 @@ module StackerBee
     attr_reader :body
 
     def body=(raw_response)
-      @body = parse(raw_response.body)
+      response_body = raw_response.body
+
+      unless html?(raw_response)
+        response_body = parse(response_body)
+      end
+
+      @body = response_body
+    end
+
+    def html?(raw_response)
+      raw_response.headers['content-type'].to_s.match(%r{/html})
     end
 
     def parse(json)

--- a/lib/stacker_bee/client.rb
+++ b/lib/stacker_bee/client.rb
@@ -68,8 +68,13 @@ module StackerBee
       request = Request.new(endpoint_for(endpoint_name), api_key, params)
       request.allow_empty_string_params =
         configuration.allow_empty_string_params
-      raw_response = connection.get(request)
+      path = path_for_endpoint(endpoint_name)
+      raw_response = connection.get(request, path)
       Response.new(raw_response)
+    end
+
+    def path_for_endpoint(endpoint_name)
+      URI.parse(configuration.url).path
     end
 
     def endpoint_for(name)

--- a/lib/stacker_bee/client.rb
+++ b/lib/stacker_bee/client.rb
@@ -7,10 +7,33 @@ require "stacker_bee/dictionary_flattener"
 require "stacker_bee/response"
 
 module StackerBee
+  module ConsoleAccess
+    ENDPOINT = "consoleAccess"
+    PATH = "/client/console"
+
+    def console_access(vm)
+      request("consoleAccess", cmd: 'access', vm: vm)
+    end
+
+    def path_for_endpoint(endpoint_name)
+      return PATH if endpoint_name == ENDPOINT
+
+      super
+    end
+
+    def endpoint_for(name)
+      return name if name == ENDPOINT
+
+      super
+    end
+  end
+
   class Client
     DEFAULT_API_PATH = File.join(
       File.dirname(__FILE__), '../../config/4.2.json'
     )
+
+    prepend ConsoleAccess
 
     extend Forwardable
     def_delegators :configuration,

--- a/lib/stacker_bee/connection.rb
+++ b/lib/stacker_bee/connection.rb
@@ -12,8 +12,7 @@ module StackerBee
 
     def initialize(configuration)
       @configuration = configuration
-      uri      = URI.parse(self.configuration.url)
-      @path    = uri.path
+      uri = URI.parse(self.configuration.url)
       uri.path = ''
       fail ConnectionError, "no protocol specified" unless uri.scheme
       initialize_faraday(uri)
@@ -28,8 +27,8 @@ module StackerBee
       end
     end
 
-    def get(request)
-      @faraday.get(@path, request.query_params)
+    def get(request, path)
+      @faraday.get(path, request.query_params)
     rescue Faraday::Error::ConnectionFailed => error
       raise ConnectionError,
         "Failed to connect to #{configuration.url}, #{error}"

--- a/spec/cassettes/A_request_sent_to_CloudStack_for_console_access/returns_html_for_console_access.yml
+++ b/spec/cassettes/A_request_sent_to_CloudStack_for_console_access/returns_html_for_console_access.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<CLOUD_STACK_HOST>/client/console?apiKey=<CLOUD_STACK_API_KEY>&cmd=access&command=consoleAccess&response=json&signature=DsI/kxaNO7AgzDCgE1j/3rtq3xU&vm=36f9c08b-f17a-4d0e-ac9b-d45ce2d34fcd"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.9
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '616'
+      Date:
+      - Tue, 11 Feb 2014 19:33:34 GMT
+    body:
+      encoding: UTF-8
+      string: "<html><title>console2</title><frameset><frame src=\"https://207-19-99-5.realhostip.com/ajax?token=FAKE_TOKEN\"></frame></frameset></html>"
+    http_version: 
+  recorded_at: Tue, 11 Feb 2014 19:34:25 GMT
+recorded_with: VCR 2.8.0

--- a/spec/integration/console_spec.rb
+++ b/spec/integration/console_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "A request sent to CloudStack for console access", :vcr do
+  let(:config_hash) do
+    {
+      url:        CONFIG['url'],
+      api_key:    CONFIG['api_key'],
+      secret_key: CONFIG['secret_key']
+    }
+  end
+
+  let(:client) do
+    StackerBee::Client.new(config_hash)
+  end
+
+  let(:vm) { "36f9c08b-f17a-4d0e-ac9b-d45ce2d34fcd" }
+
+  subject(:console_access) { client.console_access(vm) }
+
+  it "returns html for console access" do
+    expect(console_access).to match(/frame src/)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,10 @@ VCR.configure do |c|
   c.filter_sensitive_data('<CLOUD_STACK_URL>') do
     CONFIG["url"]
   end
+  c.filter_sensitive_data('<CLOUD_STACK_HOST>') do
+    uri = URI.parse(CONFIG["url"])
+    "#{uri.scheme}://#{uri.host}:#{uri.port}"
+  end
   c.filter_sensitive_data('<CLOUD_STACK_API_KEY>') do
     CONFIG["api_key"]
   end

--- a/spec/units/stacker_bee/client_spec.rb
+++ b/spec/units/stacker_bee/client_spec.rb
@@ -13,7 +13,7 @@ describe StackerBee::Client, ".api" do
 end
 
 describe StackerBee::Client, "calling endpoint" do
-  let(:url)         { "cloud-stack.com" }
+  let(:url)         { "http://cloud-stack.com" }
   let(:api_key)     { "cloud-stack-api-key" }
   let(:secret_key)  { "cloud-stack-secret-key" }
   let(:config_hash) do
@@ -42,7 +42,7 @@ describe StackerBee::Client, "calling endpoint" do
     ) do
       request
     end
-    connection.stub(:get).with(request) { raw_response }
+    connection.stub(:get).with(request, "") { raw_response }
     StackerBee::Response.stub(:new).with(raw_response) { response }
   end
 
@@ -59,7 +59,7 @@ describe StackerBee::Client, "#request" do
   let(:endpoint)    { "listVirtualMachines" }
   let(:params)      { { list: :all } }
 
-  let(:url)         { "cloud-stack.com" }
+  let(:url)         { "http://cloud-stack.com" }
   let(:api_key)     { "cloud-stack-api-key" }
   let(:secret_key)  { "cloud-stack-secret-key" }
   let(:config_hash) do
@@ -80,7 +80,7 @@ describe StackerBee::Client, "#request" do
     StackerBee::Request.should_receive(:new).with(endpoint, api_key, params) do
       request
     end
-    connection.should_receive(:get).with(request) { raw_response }
+    connection.should_receive(:get).with(request, "") { raw_response }
     StackerBee::Response.should_receive(:new).with(raw_response) { response }
   end
 
@@ -93,7 +93,7 @@ describe StackerBee::Client, "#request" do
 end
 
 describe StackerBee::Client, "configuration" do
-  let(:default_url)         { "default_cloud-stack.com" }
+  let(:default_url)         { "http://default_cloud-stack.com" }
   let(:default_api_key)     { "default-cloud-stack-api-key" }
   let(:default_secret_key)  { "default-cloud-stack-secret-key" }
   let(:default_config_hash) do
@@ -108,7 +108,7 @@ describe StackerBee::Client, "configuration" do
   let!(:default_configuration) do
     StackerBee::Configuration.new(default_config_hash)
   end
-  let(:instance_url)        { "instance-cloud-stack.com" }
+  let(:instance_url)        { "http://instance-cloud-stack.com" }
   let(:instance_api_key)    { "instance-cloud-stack-api-key" }
   let(:instance_secret_key) { "instance-cloud-stack-secret-key" }
   let(:instance_config_hash) do
@@ -163,7 +163,7 @@ describe StackerBee::Client, "configuration" do
     end
 
     describe "#url" do
-      let(:other_url) { "other-cloud-stack.com" }
+      let(:other_url) { "http://other-cloud-stack.com" }
       before { subject.url = other_url }
       its(:url) { should eq other_url }
     end

--- a/spec/units/stacker_bee/client_spec.rb
+++ b/spec/units/stacker_bee/client_spec.rb
@@ -181,3 +181,44 @@ describe StackerBee::Client, "configuration" do
     end
   end
 end
+
+describe StackerBee::Client, "#console_access" do
+  let(:config_hash) do
+    {
+      url:        CONFIG["url"],
+      api_key:    CONFIG["api_key"],
+      secret_key: CONFIG["secret_key"]
+    }
+  end
+
+  let(:client) do
+    StackerBee::Client.new(config_hash)
+  end
+
+  let(:vm) { "36f9c08b-f17a-4d0e-ac9b-d45ce2d34fcd" }
+
+  let(:body) { "<body></body>" }
+  let(:headers) { { 'content-type' => 'text/html' } }
+  let(:response_stub) do
+    double(StackerBee::Response, success?: true, body: body, headers: headers)
+  end
+
+  subject(:console_access) { client.console_access(vm) }
+
+  it "makes a request with the consoleAccess endpoint" do
+    expect(client).to receive(:request).with(
+      "consoleAccess", cmd: 'access', vm: vm
+    )
+
+    console_access
+  end
+
+  it "makes a get request to the connection" do
+    expect(client.send(:connection)).to receive(:get) do |request, path|
+      expect(request.endpoint).to eq("consoleAccess")
+      expect(path).to eq("/client/console")
+    end.and_return(response_stub)
+
+    expect(console_access).to eq(body)
+  end
+end

--- a/spec/units/stacker_bee/connection_spec.rb
+++ b/spec/units/stacker_bee/connection_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe StackerBee::Connection do
   let(:url)           { "http://test.com:1234/foo/bar/" }
+  let(:path)          { "/foo/bar" }
   let(:secret_key)    { "shhh" }
   let(:configuration) { double url: url, secret_key: secret_key }
   let(:query_params)  { [[:foo, :bar]] }
@@ -9,18 +10,18 @@ describe StackerBee::Connection do
   let(:response)      { double }
   let(:faraday)       { double get: response }
   let(:connection)    { StackerBee::Connection.new configuration }
-  subject { connection.get request }
+  subject(:get) { connection.get request, path }
   before do
     Faraday.stub(:new) { faraday }
   end
 
   context "successfully connecting" do
     before do
-      faraday.should_receive(:get).with('/foo/bar/', query_params) { response }
+      faraday.should_receive(:get).with('/foo/bar', query_params) { response }
     end
     it { should be response }
     it "specifies url without path when creating connection" do
-      subject
+      get
       Faraday.should have_received(:new).with(url: "http://test.com:1234")
     end
   end
@@ -31,7 +32,7 @@ describe StackerBee::Connection do
     end
     it "should raise helpful exception" do
       klass = StackerBee::ConnectionError
-      expect(-> { subject }).to raise_error klass, /#{url}/
+      expect { get }.to raise_error klass, /#{url}/
     end
   end
 
@@ -39,7 +40,15 @@ describe StackerBee::Connection do
     let(:url) { "wrong.com" }
     it "should raise helpful exception" do
       klass = StackerBee::ConnectionError
-      expect(-> { subject }).to raise_error klass, /no protocol/
+      expect { get }.to raise_error klass, /no protocol/
+    end
+  end
+
+  context "when given a path" do
+    let(:path) { '/baz' }
+    it "makes a request to the correct path" do
+      expect(faraday).to receive(:get).with(path, query_params)
+      connection.get request, path
     end
   end
 end

--- a/spec/units/stacker_bee/request_error_spec.rb
+++ b/spec/units/stacker_bee/request_error_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 
 describe StackerBee::RequestError, ".for" do
-  let(:raw_response) { double status: status, body: '{"foo": "bar"}' }
+  let(:raw_response) do
+    double status: status, body: '{"foo": "bar"}', headers: {}
+  end
   subject { StackerBee::RequestError.for raw_response }
 
   context "HTTP status in the 400s" do
@@ -36,7 +38,9 @@ describe StackerBee::RequestError do
     }
     EOS
   end
-  let(:raw_response) { double body: raw_body, :success? => false, status: 431 }
+  let(:raw_response) do
+    double body: raw_body, :success? => false, status: 431, headers: {}
+  end
   let(:client_error) { StackerBee::ClientError.new raw_response }
   subject { client_error }
   its(:status) { should eq http_status }

--- a/spec/units/stacker_bee/response_spec.rb
+++ b/spec/units/stacker_bee/response_spec.rb
@@ -2,8 +2,12 @@ require "spec_helper"
 
 describe StackerBee::Response do
   let(:raw_body)          { '{ "json": "here" }' }
-  let(:raw_response)  { double body: raw_body, :success? => true }
-  let(:response)      { StackerBee::Response.new raw_response }
+  let(:raw_response) do
+    double(body: raw_body, success?: true, headers: headers)
+  end
+  let(:response)     { StackerBee::Response.new raw_response }
+  let(:headers)      { { 'content-type' => content_type } }
+  let(:content_type) { "application/json; charset=UTF-8" }
   subject { response }
   its(:body) { should == 'here' }
 
@@ -44,7 +48,8 @@ describe StackerBee::Response do
       double(
         :body     => '{ "foo": "bar" }',
         :success? => false,
-        :status   => 431
+        :status   => 431,
+        :headers  => {}
       )
     end
     it { expect { subject }.to raise_exception StackerBee::ClientError }
@@ -62,7 +67,8 @@ describe StackerBee::Response do
           { "createprojectresponse" :
             {"uuidList":[],"errorcode":401,"errortext":"#{message}"} } ],
         success?: false,
-        status: 401
+        status: 401,
+        headers: {}
       )
     end
     let(:client_error) { StackerBee::AuthenticationError.new raw_response }
@@ -76,4 +82,12 @@ describe StackerBee::Response do
     end
   end
 
+  context "with an html response" do
+    let(:raw_body) { "<html><body>hi</body><html>" }
+    let(:content_type) { "text/html" }
+
+    it "returns the raw html without parsing" do
+      expect(response.body).to eq(raw_body)
+    end
+  end
 end


### PR DESCRIPTION
Adds StackerBee::Client#console_access, which takes a VM uuid and returns HTML for a frameset which contains the console for the VM.
