### PR TITLE
Continuous Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,11 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+deploy:
+  provider: rubygems
+  api_key:
+    secure: d5hC4iuoXOsrQKJRd9GSyZP2UlO2v9HsayhgNk2RlQQJFbqki6TcIlxN6j39/QER3pM3MUZyvCewtvxjrijt4f82xJGHRXaVNZvPSyD91PkGUtOuibLojc+GmwrzzRpu0d3TSEuzeKBSVag7AuJFO3oQnhEyblyZPyqWh1Ii1nM=
+  gem: stacker_bee
+  on:
+    repo: promptworks/stacker_bee
+    ruby: 2.1.0

--- a/stacker_bee.gemspec
+++ b/stacker_bee.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
 
   # Release every merge to master as a prerelease
-  spec.version = "#{spec.version}-pre#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
+  spec.version = "#{spec.version}.pre#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
 end

--- a/stacker_bee.gemspec
+++ b/stacker_bee.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
 
   # Release every merge to master as a prerelease
-  spec.version <<  "-pre#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
+  spec.version = "#{spec.version}-pre#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
 end

--- a/stacker_bee.gemspec
+++ b/stacker_bee.gemspec
@@ -32,4 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr",      "~> 2.6"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "pry"
+
+  # Release every merge to master as a prerelease
+  spec.version <<  "-pre#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
 end


### PR DESCRIPTION
Current:
- Build all merges to master as prerelease, still `rake release` locally

Other possible scenarios
- Build all branches as prerelease, still `rake release` locally
- Build all branches, append prerelease to only non-master branches (no longer need to `rake release` locally)
