### PR TITLE
Specify Ruby 2.1 instead of 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.0
+  - 2.1
   - 2.0.0
   - 1.9.3
   - 1.9.2
@@ -18,4 +18,4 @@ deploy:
   gem: stacker_bee
   on:
     repo: promptworks/stacker_bee
-    ruby: 2.1.0
+    ruby: 2.1


### PR DESCRIPTION
Ruby > 2.1 will use semantic versioning
