### PR TITLE
Cache the installed bundle on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ config.yml
 .config
 .yardoc
 Guardfile
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,10 @@ deploy:
   on:
     repo: promptworks/stacker_bee
     ruby: 2.1
+install: script/cached-bundle install --deployment
+env:
+  global:
+  - AMAZON_S3_BUCKET=stackerbee-travis
+  - AMAZON_ACCESS_KEY_ID=AKIAIOYK2S6RTFLKVMYA
+  - secure: Z80TEqte9P2ZS1NusBRzAxNMCU6N0GYExxnWtJgfWxaQy0Fsn3RvTJp0UmTsw+SS5Cvxx5lhjClA6GOGIEeirnBqVw137Cmh1K3vzbGRRPrm/WDoJQWr4EASivj7sUyCXTtRyu8OH9+1KEKWDF5lNUWqj+7ezhrWDj2nIcBJGII=
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,11 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in stacker_bee.gemspec
 gemspec
+
+gem 'bundler',  '~> 1.3'
+gem 'rake',     '~> 10.0'
+gem 'rspec',    '~> 2.1'
+gem 'webmock',  '~> 1.15'
+gem 'vcr',      '~> 2.6'
+gem 'pry'
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,69 @@
+PATH
+  remote: .
+  specs:
+    stacker_bee (2.1.0)
+      faraday (~> 0.8, < 0.9)
+      faraday_middleware (~> 0.9)
+      multi_json (~> 1.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.6)
+    ast (1.1.0)
+    coderay (1.1.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.2.5)
+    faraday (0.8.9)
+      multipart-post (~> 1.2.0)
+    faraday_middleware (0.9.0)
+      faraday (>= 0.7.4, < 0.9)
+    json (1.8.1)
+    method_source (0.8.2)
+    multi_json (1.9.2)
+    multipart-post (1.2.0)
+    parser (2.1.7)
+      ast (~> 1.1)
+      slop (~> 3.4, >= 3.4.5)
+    powerpack (0.0.9)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    rainbow (2.0.0)
+    rake (10.2.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+    rubocop (0.20.1)
+      json (>= 1.7.7, < 2)
+      parser (~> 2.1.7)
+      powerpack (~> 0.0.6)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    ruby-progressbar (1.4.2)
+    safe_yaml (1.0.2)
+    slop (3.5.0)
+    vcr (2.9.0)
+    webmock (1.17.4)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.3)
+  pry
+  rake (~> 10.0)
+  rspec (~> 2.1)
+  rubocop
+  stacker_bee!
+  vcr (~> 2.6)
+  webmock (~> 1.15)

--- a/script/cached-bundle
+++ b/script/cached-bundle
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Usage: cached-bundle install --deployment
+#
+# After running `bundle`, caches the `vendor/bundle` directory to S3.
+# On the next run, restores the cached directory before running `bundle`.
+# When `Gemfile.lock` changes, the cache gets rebuilt.
+#
+# Requirements:
+# - Gemfile.lock
+# - TRAVIS_REPO_SLUG
+# - TRAVIS_RUBY_VERSION
+# - AMAZON_S3_BUCKET
+# - script/s3-put
+# - bundle
+# - curl
+#
+# Author: Mislav Marohnić
+
+set -e
+
+compute_md5() {
+  local output="$(openssl md5)"
+  echo "${output##* }"
+}
+
+download() {
+  curl --tcp-nodelay -qsfL "$1" -o "$2"
+}
+
+bundle_path="vendor/bundle"
+gemfile_hash="$(compute_md5 <"${BUNDLE_GEMFILE:-Gemfile}.lock")"
+cache_name="${TRAVIS_RUBY_VERSION}-${gemfile_hash}.tgz"
+fetch_url="http://${AMAZON_S3_BUCKET}.s3.amazonaws.com/${TRAVIS_REPO_SLUG}/${cache_name}"
+
+if download "$fetch_url" "$cache_name"; then
+  echo "Reusing cached bundle ${cache_name}"
+  tar xzf "$cache_name"
+fi
+
+bundle "$@"
+
+if [ ! -f "$cache_name" ]; then
+  echo "Caching \`${bundle_path}' to S3"
+  tar czf "$cache_name" "$bundle_path"
+  script/s3-put "$cache_name" "${AMAZON_S3_BUCKET}:${TRAVIS_REPO_SLUG}/${cache_name}"
+fi

--- a/script/s3-put
+++ b/script/s3-put
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Usage: s3-put <FILE> <S3_BUCKET>[:<PATH>] [<CONTENT_TYPE>]
+#
+# Uploads a file to the Amazon S3 service.
+# Outputs the URL for the newly uploaded file.
+#
+# Requirements:
+# - AMAZON_ACCESS_KEY_ID
+# - AMAZON_SECRET_ACCESS_KEY
+# - openssl
+# - curl
+#
+# Author: Mislav Marohnić
+
+set -e
+
+authorization() {
+  local signature="$(string_to_sign | hmac_sha1 | base64)"
+  echo "AWS ${AMAZON_ACCESS_KEY_ID?}:${signature}"
+}
+
+hmac_sha1() {
+  openssl dgst -binary -sha1 -hmac "${AMAZON_SECRET_ACCESS_KEY?}"
+}
+
+base64() {
+  openssl enc -base64
+}
+
+bin_md5() {
+  openssl dgst -binary -md5
+}
+
+string_to_sign() {
+  echo "$http_method"
+  echo "$content_md5"
+  echo "$content_type"
+  echo "$date"
+  echo "x-amz-acl:$acl"
+  printf "/$bucket/$remote_path"
+}
+
+date_string() {
+  LC_TIME=C date "+%a, %d %h %Y %T %z"
+}
+
+file="$1"
+bucket="${2%%:*}"
+remote_path="${2#*:}"
+content_type="$3"
+
+if [ -z "$remote_path" ] || [ "$remote_path" = "$bucket" ]; then
+  remote_path="${file##*/}"
+fi
+
+http_method=PUT
+acl="public-read"
+content_md5="$(bin_md5 < "$file" | base64)"
+date="$(date_string)"
+
+url="https://$bucket.s3.amazonaws.com/$remote_path"
+
+curl -qsSf -T "$file" \
+  -H "Authorization: $(authorization)" \
+  -H "x-amz-acl: $acl" \
+  -H "Date: $date" \
+  -H "Content-MD5: $content_md5" \
+  -H "Content-Type: $content_type" \
+  "$url"
+
+echo "$url"

--- a/stacker_bee.gemspec
+++ b/stacker_bee.gemspec
@@ -19,22 +19,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday",            "~> 0.8", "< 0.9"
-  spec.add_runtime_dependency 'multi_json',         "~> 1.8"
+  spec.add_runtime_dependency "faraday",    "~> 0.8", "< 0.9"
+  spec.add_runtime_dependency 'multi_json', "~> 1.8"
 
   # this is a dependency for FaradayMiddleware::Graylog
   spec.add_runtime_dependency "faraday_middleware", "~> 0.9"
-
-  spec.add_development_dependency "bundler",  "~> 1.3"
-  spec.add_development_dependency "rake",     "~> 10.0"
-  spec.add_development_dependency "rspec",    "~> 2.1"
-  spec.add_development_dependency "webmock",  "~> 1.15"
-  spec.add_development_dependency "vcr",      "~> 2.6"
-  spec.add_development_dependency "pry"
-
-  # It should be consistent for Travis and all developers, since we don't check
-  # in the Gemfile.lock
-  spec.add_development_dependency "rubocop",  "0.20.1"
 
   # Release every merge to master as a prerelease
   spec.version = "#{spec.version}.pre#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']


### PR DESCRIPTION
This is for #44.

Unfortunately, it doesn't build on Travis because the Gemfile.lock is committed (which is necessary for this bundle caching scheme).

To demonstrate, [here's a build on Travis ](https://travis-ci.org/promptworks/stacker_bee/jobs/22860442) that fails because the Gemfile.lock is committed ([here's the commit](https://github.com/promptworks/stacker_bee/commit/202e407cdc3ebb6727ffc2f369136dce18e488da)). It bundles locally just fine.

Any ideas? @justincampbell ?
