### PR TITLE
Make Configuration class stricter

### DIFF
--- a/lib/stacker_bee/builder.rb
+++ b/lib/stacker_bee/builder.rb
@@ -1,6 +1,6 @@
 module StackerBee
   class Builder
-    attr_accessor :middlewares
+    attr_writer :middlewares
 
     def middlewares
       @middlewares ||= []

--- a/lib/stacker_bee/configuration.rb
+++ b/lib/stacker_bee/configuration.rb
@@ -1,11 +1,63 @@
-require "ostruct"
-
 module StackerBee
-  class Configuration < OpenStruct
+  class Configuration
+    class NoAttributeError < StandardError
+    end
+
+    ATTRIBUTES = [
+      :ssl_verify,
+      :url,
+      :secret_key,
+      :api_key,
+      :middlewares,
+      :faraday_middlewares
+    ]
+
+    def initialize(attrs = nil)
+      @attributes = attrs || {}
+
+      @attributes.each_pair do |key, value|
+        unless ATTRIBUTES.include?(key)
+          fail NoAttributeError, "No attribute defined: '#{key}'"
+        end
+      end
+    end
+
     def ssl_verify?
-      # rubocop:disable NonNilCheck
-      # it should default to true if it's not explicitly set
-      !ssl_verify.nil? ? ssl_verify : true
+      attribute :ssl_verify, true
+    end
+
+    def url
+      attribute :url
+    end
+
+    def secret_key
+      attribute :secret_key
+    end
+
+    def api_key
+      attribute :api_key
+    end
+
+    def middlewares
+      attribute :middlewares, proc {}
+    end
+
+    def faraday_middlewares
+      attribute :faraday_middlewares, proc {}
+    end
+
+    def to_hash
+      @attributes
+    end
+
+    def merge(other)
+      self.class.new(to_hash.merge(other.to_hash))
+    end
+
+    private
+
+    def attribute(key, value = nil)
+      @attributes.fetch(key, value)
     end
   end
 end

--- a/lib/stacker_bee/middleware/environment.rb
+++ b/lib/stacker_bee/middleware/environment.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module StackerBee
   module Middleware
     class Environment < OpenStruct

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -7,10 +7,9 @@ describe "A response to a request sent to the CloudStack API", :vcr do
   let(:url) { CONFIG["url"] }
   let(:config_hash) do
     {
-      url:        url,
-      api_key:    CONFIG["api_key"],
-      secret_key: CONFIG["secret_key"],
-      apis_path:  File.join(File.dirname(__FILE__), '../fixtures/4.2.json'),
+      url:         url,
+      api_key:     CONFIG["api_key"],
+      secret_key:  CONFIG["secret_key"],
       middlewares: middlewares
     }
   end

--- a/spec/units/stacker_bee/client_spec.rb
+++ b/spec/units/stacker_bee/client_spec.rb
@@ -61,6 +61,8 @@ describe StackerBee::Client, "calling endpoint" do
 end
 
 describe StackerBee::Client, "configuration" do
+  before { described_class.configuration = default_config_hash }
+
   let(:default_url)         { "default_cloud-stack.com" }
   let(:default_api_key)     { "default-cloud-stack-api-key" }
   let(:default_secret_key)  { "default-cloud-stack-secret-key" }
@@ -73,9 +75,7 @@ describe StackerBee::Client, "configuration" do
       middlewares:         proc {}
     }
   end
-  let!(:default_configuration) do
-    StackerBee::Configuration.new(default_config_hash)
-  end
+
   let(:instance_url)        { "instance-cloud-stack.com" }
   let(:instance_api_key)    { "instance-cloud-stack-api-key" }
   let(:instance_secret_key) { "instance-cloud-stack-secret-key" }
@@ -88,64 +88,44 @@ describe StackerBee::Client, "configuration" do
       middlewares:         proc {}
     }
   end
-  let!(:instance_configuration) do
-    StackerBee::Configuration.new(instance_config_hash)
-  end
-  before do
-    StackerBee::Configuration.stub(:new) do
-      fail "Unexpected Configuration instantiation: \n#{args.inspect}"
-    end
-    StackerBee::Configuration.stub(:new).with(default_config_hash) do
-      default_configuration
-    end
-    StackerBee::Configuration.stub(:new).with(instance_config_hash) do
-      instance_configuration
-    end
-    described_class.configuration = default_config_hash
-  end
 
   describe ".new" do
-    subject { described_class.new }
+    subject { client.configuration }
 
     context "with default, class configuration" do
-      its(:url)           { should eq default_url }
-      its(:api_key)       { should eq default_api_key }
-      its(:secret_key)    { should eq default_secret_key }
+      let(:client) { described_class.new }
+
+      its(:url)        { should eq default_url }
+      its(:api_key)    { should eq default_api_key }
+      its(:secret_key) { should eq default_secret_key }
     end
 
     context "with instance-specific configuration" do
-      subject { described_class.new(instance_config_hash) }
-      its(:configuration) { should eq instance_configuration }
-      its(:url)           { should eq instance_url }
-      its(:api_key)       { should eq instance_api_key }
-      its(:secret_key)    { should eq instance_secret_key }
+      let(:client) { described_class.new(instance_config_hash) }
+
+      its(:url)        { should eq instance_url }
+      its(:api_key)    { should eq instance_api_key }
+      its(:secret_key) { should eq instance_secret_key }
     end
 
     context "with instance-specific configuration that's not a hash" do
-      subject { described_class.new(config) }
+      let(:client) { described_class.new(config) }
       let(:config) { double(to_hash: instance_config_hash) }
-      its(:configuration) { should eq instance_configuration }
-      its(:url)           { should eq instance_url }
-      its(:api_key)       { should eq instance_api_key }
-      its(:secret_key)    { should eq instance_secret_key }
+
+      its(:url)        { should eq instance_url }
+      its(:api_key)    { should eq instance_api_key }
+      its(:secret_key) { should eq instance_secret_key }
     end
 
-    describe "#url" do
-      let(:other_url) { "other-cloud-stack.com" }
-      before { subject.url = other_url }
-      its(:url) { should eq other_url }
-    end
+    context "with partial instance-specific configuration" do
+      let(:client) { described_class.new(partial_config_hash) }
+      let(:partial_config_hash) do
+        { url: instance_config_hash[:url] }
+      end
 
-    describe "#api_key" do
-      let(:other_api_key) { "other-cloud-stack-api-key" }
-      before { subject.api_key = other_api_key }
-      its(:api_key) { should eq other_api_key }
-    end
-
-    describe "#secret_key" do
-      let(:other_secret_key) { "other-cloud-stack-secret-key" }
-      before { subject.secret_key = other_secret_key }
-      its(:secret_key) { should eq other_secret_key }
+      its(:url)        { should eq instance_url }
+      its(:api_key)    { should eq default_api_key }
+      its(:secret_key) { should eq default_secret_key }
     end
   end
 end

--- a/spec/units/stacker_bee/configuration_spec.rb
+++ b/spec/units/stacker_bee/configuration_spec.rb
@@ -1,25 +1,169 @@
 require "spec_helper"
 
 describe StackerBee::Configuration do
-  its(:url)        { should be_nil }
-  its(:api_key)    { should be_nil }
-  its(:secret_key) { should be_nil }
+  describe "setting an attribute that doesn't exist" do
+    [:ssl_verify?, :url?, :other_attr].each do |attr|
+      it "raises an error" do
+        expect { described_class.new(attr => true) }
+          .to raise_error described_class::NoAttributeError, /#{attr}/
+      end
+    end
+  end
 
   describe "#ssl_verify?" do
     subject { configuration.ssl_verify? }
-    let(:configuration) { described_class.new(ssl_verify: ssl_verify) }
 
-    context "when nil" do
-      let(:ssl_verify) { nil }
+    context "when not set" do
+      let(:configuration) { described_class.new }
       it { should eq true }
     end
-    context "when false" do
-      let(:ssl_verify) { false }
+
+    context "when set to false" do
+      let(:configuration) { described_class.new(ssl_verify: false) }
       it { should eq false }
     end
-    context "when true" do
-      let(:ssl_verify) { true }
+
+    context "when set to true" do
+      let(:configuration) { described_class.new(ssl_verify: true) }
       it { should eq true }
+    end
+  end
+
+  describe "#url" do
+    subject { configuration.url }
+
+    context "when not set" do
+      let(:configuration) { described_class.new }
+      it { should eq nil }
+    end
+
+    context "when set" do
+      let(:configuration) { described_class.new(url: setting) }
+      let(:setting) { "http://example.com" }
+      it { should eq setting }
+    end
+  end
+
+  describe "#secret_key" do
+    subject { configuration.secret_key }
+
+    context "when not set" do
+      let(:configuration) { described_class.new }
+      it { should eq nil }
+    end
+
+    context "when set" do
+      let(:configuration) { described_class.new(secret_key: setting) }
+      let(:setting) { "qwertyuiop" }
+      it { should eq setting }
+    end
+  end
+
+  describe "#api_key" do
+    subject { configuration.api_key }
+
+    context "when not set" do
+      let(:configuration) { described_class.new }
+      it { should eq nil }
+    end
+
+    context "when set" do
+      let(:configuration) { described_class.new(api_key: setting) }
+      let(:setting) { "qwertyuiop" }
+      it { should eq setting }
+    end
+  end
+
+  describe "#middlewares" do
+    subject { configuration.middlewares }
+
+    context "when not set" do
+      let(:configuration) { described_class.new }
+      it { should be_a Proc }
+    end
+
+    context "when set" do
+      let(:configuration) { described_class.new(middlewares: setting) }
+      let(:setting) { proc { something } }
+      it { should eq setting }
+    end
+  end
+
+  describe "#faraday_middlewares" do
+    subject { configuration.faraday_middlewares }
+
+    context "when not set" do
+      let(:configuration) { described_class.new }
+      it { should be_a Proc }
+    end
+
+    context "when set" do
+      let(:configuration) { described_class.new(faraday_middlewares: setting) }
+      let(:setting) { proc { something } }
+      it { should eq setting }
+    end
+  end
+
+  describe "#merge" do
+    subject { parent.merge(child) }
+
+    let(:parent) do
+      described_class.new(
+        url: :parent_url,
+        api_key: :parent_api_key,
+        secret_key: :parent_secret_key,
+        ssl_verify: :parent_ssl_verify,
+        middlewares: :parent_ssl_middlewares,
+        faraday_middlewares: :parent_faraday_middlewares
+      )
+    end
+
+    let(:child) do
+      described_class.new(
+        url: :child_url,
+        api_key: :child_api_key,
+        secret_key: :child_secret_key,
+        ssl_verify: :child_ssl_verify,
+        middlewares: :child_ssl_middlewares,
+        faraday_middlewares: :child_faraday_middlewares
+      )
+    end
+
+    context "when the child doesn't have an attribute set" do
+      let(:child) { described_class.new }
+      it "uses the attribute of the parent" do
+        subject.url.should eq :parent_url
+        subject.api_key.should eq :parent_api_key
+        subject.secret_key.should eq :parent_secret_key
+        subject.ssl_verify?.should eq :parent_ssl_verify
+        subject.middlewares.should eq :parent_ssl_middlewares
+        subject.faraday_middlewares.should eq :parent_faraday_middlewares
+      end
+    end
+
+    context "when the parent doesn't have an attribute set" do
+      let(:parent) { described_class.new }
+      it "uses the attribute of the child" do
+        subject.url.should eq :child_url
+        subject.api_key.should eq :child_api_key
+        subject.secret_key.should eq :child_secret_key
+        subject.ssl_verify?.should eq :child_ssl_verify
+        subject.middlewares.should eq :child_ssl_middlewares
+        subject.faraday_middlewares.should eq :child_faraday_middlewares
+      end
+    end
+
+    context "when the parent and child don't have an attribut set" do
+      let(:child) { described_class.new }
+      let(:parent) { described_class.new }
+      it "uses the defaults of the attributes of the child" do
+        subject.url.should eq nil
+        subject.api_key.should eq nil
+        subject.secret_key.should eq nil
+        subject.ssl_verify?.should eq true
+        subject.middlewares.should be_a Proc
+        subject.faraday_middlewares.should be_a Proc
+      end
     end
   end
 end

--- a/stacker_bee.gemspec
+++ b/stacker_bee.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday",            "~> 0.8", "< 0.9"
-  spec.add_runtime_dependency 'multi_json',         "~> 1.8"
+  spec.add_runtime_dependency "faraday",    "~> 0.8", "< 0.9"
+  spec.add_runtime_dependency 'multi_json', "~> 1.8"
 
   # this is a dependency for FaradayMiddleware::Graylog
   spec.add_runtime_dependency "faraday_middleware", "~> 0.9"


### PR DESCRIPTION
- Configuration is no longer an OpenStruct. Instead, it has a whitelist
  of attributes. Trying to set non-existent attributes throws a
  NoMethodError.
- Configuration class defines the defaults instead of the Client class.
- Configuration class handles merging instead of the Client class.
- Dry up configuration logic in Client class.
- Define an Attributes module that provides a small DSL for defining
  attributes, their defaults, initialization, and an #attributes method
