### PR TITLE
fix --config regression in bin/stacker_bee

### DIFF
--- a/bin/stacker_bee
+++ b/bin/stacker_bee
@@ -55,9 +55,9 @@ begin
   optparse.parse!
   if options[:config]
     hash = File.read options[:config]
-    options.merge! YAML.load(hash)
+    options.merge! Hash[YAML.load(hash).map { |k,v| [k.to_sym, v] }]
   end
-  unless ([:api_key, :secret_key, :url] - options.keys).empty?
+  unless options.keys.include?(:config) or ([:api_key, :secret_key, :url] - options.keys).empty?
     puts "Please specify a config file or all of the following: " \
          "--api_key, --secret_key and --url"
     exit

--- a/lib/stacker_bee/configuration.rb
+++ b/lib/stacker_bee/configuration.rb
@@ -16,6 +16,7 @@ module StackerBee
       @attributes = attrs || {}
 
       @attributes.each_pair do |key, value|
+        next if key == :config
         unless ATTRIBUTES.include?(key)
           fail NoAttributeError, "No attribute defined: '#{key}'"
         end


### PR DESCRIPTION
bin/stacker_bee crashes if you try to pass a config file. this fixes that regression in bin/stacker_bee

it doesn't add a test or refactor bin/stacker_bee to a CLI object - that'll be a different PR ;)
